### PR TITLE
ci: use npm ci instead of npm install in wc-deploy

### DIFF
--- a/.github/workflows/wc-deploy.yaml
+++ b/.github/workflows/wc-deploy.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - name: Push changes to the remote branch
         if: inputs.is_deploy


### PR DESCRIPTION
## Summary

- Use \`npm ci\` instead of \`npm install\` in \`.github/workflows/wc-deploy.yaml\` for reproducible installs from \`package-lock.json\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)